### PR TITLE
added get comments on a particular task and also a single comments us…

### DIFF
--- a/TaskManager/src/main/java/com/amalitechtaskmanager/handlers/comment/GetCommentByIdHandler.java
+++ b/TaskManager/src/main/java/com/amalitechtaskmanager/handlers/comment/GetCommentByIdHandler.java
@@ -1,0 +1,104 @@
+package com.amalitechtaskmanager.handlers.comment;
+
+import com.amalitechtaskmanager.model.Comment;
+import com.amazonaws.services.lambda.runtime.Context;
+import com.amazonaws.services.lambda.runtime.RequestHandler;
+import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
+import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
+import software.amazon.awssdk.services.dynamodb.model.GetItemRequest;
+import software.amazon.awssdk.services.dynamodb.model.GetItemResponse;
+import software.amazon.awssdk.services.dynamodb.model.DynamoDbException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+
+import java.time.LocalDateTime;
+import java.util.HashMap;
+import java.util.Map;
+
+public class GetCommentByIdHandler implements RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> {
+
+    private final DynamoDbClient dynamoDbClient;
+    private static final String TABLE_NAME = System.getenv("TABLE_NAME");
+    private final ObjectMapper objectMapper;
+
+    public GetCommentByIdHandler() {
+        this.dynamoDbClient = DynamoDbClient.create();
+        this.objectMapper = new ObjectMapper();
+        objectMapper.registerModule(new JavaTimeModule());
+        objectMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+    }
+
+    public GetCommentByIdHandler(DynamoDbClient dynamoDbClient) {
+        this.dynamoDbClient = dynamoDbClient;
+        this.objectMapper = new ObjectMapper();
+        objectMapper.registerModule(new JavaTimeModule());
+        objectMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+    }
+
+    @Override
+    public APIGatewayProxyResponseEvent handleRequest(APIGatewayProxyRequestEvent input, Context context) {
+        try {
+            // Get commentId from path parameters
+            Map<String, String> pathParameters = input.getPathParameters();
+            if (pathParameters == null || !pathParameters.containsKey("commentId")) {
+                return createResponse(400, "Missing commentId parameter");
+            }
+
+            String commentId = pathParameters.get("commentId");
+
+            // Create a key to get the specific comment
+            Map<String, AttributeValue> key = new HashMap<>();
+            key.put("commentId", AttributeValue.builder().s(commentId).build());
+
+            // Execute the GetItem operation
+            GetItemResponse getItemResponse = dynamoDbClient.getItem(
+                    GetItemRequest.builder()
+                            .tableName(TABLE_NAME)
+                            .key(key)
+                            .build());
+
+            // Check if the item exists
+            if (getItemResponse.item() == null || getItemResponse.item().isEmpty()) {
+                return createResponse(404, "Comment not found");
+            }
+
+            // Convert DynamoDB item to Comment object
+            Map<String, AttributeValue> item = getItemResponse.item();
+            Comment comment = new Comment();
+            comment.setCommentId(item.get("commentId").s());
+            comment.setTaskId(item.get("taskId").s());
+            comment.setUserId(item.get("userId").s());
+            comment.setContent(item.get("content").s());
+            comment.setCreatedAt(LocalDateTime.parse(item.get("createdAt").s()));
+            comment.setUpdatedAt(LocalDateTime.parse(item.get("updatedAt").s()));
+
+            // Return the comment
+            return createResponse(200, objectMapper.writeValueAsString(comment));
+
+        } catch (JsonProcessingException e) {
+            return createResponse(400, "Error processing JSON: " + e.getMessage());
+        } catch (DynamoDbException e) {
+            context.getLogger().log("DynamoDB error: " + e.getMessage());
+            return createResponse(500, "Failed to retrieve comment: " + e.getMessage());
+        } catch (Exception e) {
+            context.getLogger().log("Unexpected error: " + e.getMessage());
+            return createResponse(500, "Unexpected error occurred");
+        }
+    }
+
+    private APIGatewayProxyResponseEvent createResponse(int statusCode, String body) {
+        APIGatewayProxyResponseEvent response = new APIGatewayProxyResponseEvent();
+        response.setStatusCode(statusCode);
+        response.setBody(body);
+
+        Map<String, String> headers = new HashMap<>();
+        headers.put("Content-Type", "application/json");
+        response.setHeaders(headers);
+
+        return response;
+    }
+}

--- a/TaskManager/src/main/java/com/amalitechtaskmanager/handlers/comment/GetCommentsByTaskIdHandler.java
+++ b/TaskManager/src/main/java/com/amalitechtaskmanager/handlers/comment/GetCommentsByTaskIdHandler.java
@@ -1,0 +1,105 @@
+package com.amalitechtaskmanager.handlers.comment;
+
+import com.amalitechtaskmanager.model.Comment;
+import com.amazonaws.services.lambda.runtime.Context;
+import com.amazonaws.services.lambda.runtime.RequestHandler;
+import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
+import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
+import software.amazon.awssdk.services.dynamodb.model.*;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class GetCommentsByTaskIdHandler implements RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> {
+
+    private final DynamoDbClient dynamoDbClient;
+    private static final String TABLE_NAME = System.getenv("TABLE_NAME");
+    private final ObjectMapper objectMapper;
+
+    public GetCommentsByTaskIdHandler() {
+        this.dynamoDbClient = DynamoDbClient.create();
+        this.objectMapper = new ObjectMapper();
+        objectMapper.registerModule(new JavaTimeModule());
+        objectMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+    }
+
+    public GetCommentsByTaskIdHandler(DynamoDbClient dynamoDbClient) {
+        this.dynamoDbClient = dynamoDbClient;
+        this.objectMapper = new ObjectMapper();
+        objectMapper.registerModule(new JavaTimeModule());
+        objectMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+    }
+
+    @Override
+    public APIGatewayProxyResponseEvent handleRequest(APIGatewayProxyRequestEvent input, Context context) {
+        try {
+            // Get taskId from path parameters
+            Map<String, String> pathParameters = input.getPathParameters();
+            if (pathParameters == null || !pathParameters.containsKey("taskId")) {
+                return createResponse(400, "Missing taskId parameter");
+            }
+
+            String taskId = pathParameters.get("taskId");
+
+            // Set up the query
+            Map<String, AttributeValue> expressionAttributeValues = new HashMap<>();
+            expressionAttributeValues.put(":taskId", AttributeValue.builder().s(taskId).build());
+
+            // Create a query request
+            QueryRequest queryRequest = QueryRequest.builder()
+                    .tableName(TABLE_NAME)
+                    .indexName("taskId-index")  // Make sure this GSI exists on your table
+                    .keyConditionExpression("taskId = :taskId")
+                    .expressionAttributeValues(expressionAttributeValues)
+                    .build();
+
+            // Execute the query
+            QueryResponse queryResponse = dynamoDbClient.query(queryRequest);
+
+            // Process the results
+            List<Comment> comments = new ArrayList<>();
+            for (Map<String, AttributeValue> item : queryResponse.items()) {
+                Comment comment = new Comment();
+                comment.setCommentId(item.get("commentId").s());
+                comment.setTaskId(item.get("taskId").s());
+                comment.setUserId(item.get("userId").s());
+                comment.setContent(item.get("content").s());
+                comment.setCreatedAt(LocalDateTime.parse(item.get("createdAt").s()));
+                comment.setUpdatedAt(LocalDateTime.parse(item.get("updatedAt").s()));
+                comments.add(comment);
+            }
+
+            // Return the comments
+            return createResponse(200, objectMapper.writeValueAsString(comments));
+
+        } catch (JsonProcessingException e) {
+            return createResponse(400, "Error processing JSON: " + e.getMessage());
+        } catch (DynamoDbException e) {
+            context.getLogger().log("DynamoDB error: " + e.getMessage());
+            return createResponse(500, "Failed to retrieve comments: " + e.getMessage());
+        } catch (Exception e) {
+            context.getLogger().log("Unexpected error: " + e.getMessage());
+            return createResponse(500, "Unexpected error occurred");
+        }
+    }
+
+    private APIGatewayProxyResponseEvent createResponse(int statusCode, String body) {
+        APIGatewayProxyResponseEvent response = new APIGatewayProxyResponseEvent();
+        response.setStatusCode(statusCode);
+        response.setBody(body);
+
+        Map<String, String> headers = new HashMap<>();
+        headers.put("Content-Type", "application/json");
+        response.setHeaders(headers);
+
+        return response;
+    }
+}

--- a/template.yaml
+++ b/template.yaml
@@ -127,13 +127,20 @@ Resources:
       AttributeDefinitions:
         - AttributeName: commentId
           AttributeType: S
+        - AttributeName: taskId
+          AttributeType: S
       KeySchema:
         - AttributeName: commentId
           KeyType: HASH
       BillingMode: PAY_PER_REQUEST
-      Tags:
-        - Key: Component
-          Value: DynamoDB
+      GlobalSecondaryIndexes:
+        - IndexName: taskId-index
+          KeySchema:
+            - AttributeName: taskId
+              KeyType: HASH
+          Projection:
+            ProjectionType: ALL
+
 
   #============================================================================
   # SNS and SQS Resources
@@ -313,6 +320,13 @@ Resources:
               - Effect: Allow
                 Action: iam:PassRole
                 Resource: !GetAtt EventBridgeSchedulerRole.Arn
+              - Effect: Allow
+                Action:
+                  - dynamodb:Query
+                Resource:
+                  - !GetAtt CommentsTable.Arn
+                  - !Sub "${CommentsTable.Arn}/index/taskId-index"
+
       Tags:
         - Key: Component
           Value: Lambda
@@ -1239,12 +1253,13 @@ Resources:
       Runtime: java21
       MemorySize: 512
       Timeout: 30
+      Role: !GetAtt LambdaExecutionRole.Arn
       Environment:
         Variables:
-          TABLE_NAME: Comments
+          TABLE_NAME: Comment
       Policies:
         - DynamoDBWritePolicy:
-            TableName: Comments
+            TableName: Comment
       Events:
         CreateCommentApi:
           Type: Api
@@ -1252,6 +1267,53 @@ Resources:
             RestApiId: !Ref ApiGateway
             Path: /comments/post
             Method: POST
+
+
+
+  GetCommentsByTaskIdFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: TaskManager/
+      Handler: com.amalitechtaskmanager.handlers.comment.GetCommentsByTaskIdHandler::handleRequest
+      Runtime: java21
+      MemorySize: 512
+      Timeout: 30
+      Role: !GetAtt LambdaExecutionRole.Arn
+      Environment:
+        Variables:
+          TABLE_NAME: Comment
+      Policies:
+        - DynamoDBReadPolicy:
+            TableName: Comment
+      Events:
+        GetCommentsByTaskIdApi:
+          Type: Api
+          Properties:
+            RestApiId: !Ref ApiGateway
+            Path: /tasks/{taskId}/comments
+            Method: GET
+
+  GetCommentByIdFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: TaskManager/
+      Handler: com.amalitechtaskmanager.handlers.comment.GetCommentByIdHandler::handleRequest
+      Runtime: java21
+      MemorySize: 512
+      Timeout: 30
+      Role: !GetAtt LambdaExecutionRole.Arn
+      Environment:
+        Variables:
+          TABLE_NAME: Comment
+      Events:
+        GetCommentByIdApi:
+          Type: Api
+          Properties:
+            RestApiId: !Ref ApiGateway
+            Path: /comments/{commentId}
+            Method: GET
+
+
 
   DeleteCommentFunction:
     Type: AWS::Serverless::Function
@@ -1263,7 +1325,7 @@ Resources:
       Timeout: 30
       Environment:
         Variables:
-          TABLE_NAME: Comments
+          TABLE_NAME: Comment
       Policies:
         - Version: "2012-10-17"
           Statement:


### PR DESCRIPTION
# Add Comment API Endpoints

## Description
This PR adds two new endpoints to the Comment API:

1. **Get Comments by Task ID**: Allows retrieving all comments associated with a specific task
2. **Get Comment by ID**: Allows retrieving a single comment by its unique identifier

## Changes
- Created `GetCommentsByTaskIdHandler` to retrieve all comments for a task using a GSI
- Created `GetCommentByIdHandler` to retrieve a single comment by its ID
- Updated SAM template to include the new Lambda functions and API endpoints
- Added appropriate DynamoDB read permissions for the new functions

## API Endpoints Added
- `GET /tasks/{taskId}/comments` - Returns all comments for a specific task
- `GET /comments/{commentId}` - Returns a specific comment by ID

## Technical Notes
- The implementation for getting comments by task ID assumes a GSI on the Comments table with the `taskId` field as the partition key
- Both handlers include proper error handling for missing parameters, non-existent resources, and DynamoDB exceptions
- Response formatting is consistent with the existing `CreateCommentHandler`
